### PR TITLE
fix: Don't add labels/annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ module "restricted_apis" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.57 |
-| <a name="requirement_volterra"></a> [volterra](#requirement\_volterra) | 0.11.20 |
+| <a name="requirement_volterra"></a> [volterra](#requirement\_volterra) | >= 0.11.20 |
 
 ## Modules
 
@@ -79,8 +79,8 @@ module "restricted_apis" {
 
 | Name | Type |
 |------|------|
-| [volterra_gcp_vpc_site.site](https://registry.terraform.io/providers/volterraedge/volterra/0.11.20/docs/resources/gcp_vpc_site) | resource |
-| [volterra_tf_params_action.site](https://registry.terraform.io/providers/volterraedge/volterra/0.11.20/docs/resources/tf_params_action) | resource |
+| [volterra_gcp_vpc_site.site](https://registry.terraform.io/providers/volterraedge/volterra/latest/docs/resources/gcp_vpc_site) | resource |
+| [volterra_tf_params_action.site](https://registry.terraform.io/providers/volterraedge/volterra/latest/docs/resources/tf_params_action) | resource |
 | [google_compute_subnetwork.inside](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 | [google_compute_subnetwork.outside](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 | [google_compute_zones.zones](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |

--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,8 @@ terraform {
       version = ">= 4.57"
     }
     volterra = {
-      source = "volterraedge/volterra"
-      # NOTE: Performance enhancement mode changed again in 0.11.20
-      version = "0.11.20"
+      source  = "volterraedge/volterra"
+      version = ">= 0.11.20"
     }
   }
 }
@@ -28,14 +27,6 @@ data "google_compute_zones" "zones" {
 }
 
 locals {
-  labels = merge({
-    source      = "terraform-volterra-gcp-vpc-site"
-    provisioner = "terraform"
-  }, var.labels)
-  annotations = merge({
-    "community.f5.com/source"      = "github.com/memes/terraform-volterra-gcp-vpc-site"
-    "community.f5.com/provisioner" = "terraform"
-  }, var.annotations)
   zones = coalescelist(try(var.vm_options.zones, []), data.google_compute_zones.zones.names)
 }
 
@@ -51,8 +42,8 @@ resource "volterra_gcp_vpc_site" "site" {
   name          = var.name
   namespace     = "system"
   description   = coalesce(var.description, "GCP VPC Site")
-  annotations   = local.annotations
-  labels        = local.labels
+  annotations   = var.annotations
+  labels        = var.labels
   disk_size     = try(var.vm_options.disk_size, 80)
   gcp_labels    = var.gcp_labels
   gcp_region    = data.google_compute_subnetwork.outside.region

--- a/test/fixtures/root/main.tf
+++ b/test/fixtures/root/main.tf
@@ -12,21 +12,14 @@ terraform {
   }
 }
 
-locals {
-  labels = merge({}, var.labels)
-  annotations = merge({
-    "community.f5.com/submodule" = "root"
-  }, var.annotations)
-}
-
 module "test" {
   source                 = "./../../../"
   name                   = var.name
   description            = var.description
   subnets                = var.subnets
   cloud_credential_name  = var.cloud_credential_name
-  labels                 = local.labels
-  annotations            = local.annotations
+  labels                 = var.labels
+  annotations            = var.annotations
   vm_options             = var.vm_options
   site_options           = var.site_options
   dc_cluster_group       = var.dc_cluster_group

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -61,28 +61,7 @@ resource "random_shuffle" "zones" {
 }
 
 locals {
-  prefix = random_pet.prefix.id
-  labels = merge({
-    source      = "terraform-volterra-gcp-vpc-site"
-    provisioner = "terraform"
-    use-case    = "automated-testing"
-    product     = "terraform-google-volterra"
-    driver      = "kitchen-terraform"
-  }, var.labels)
-  annotations = merge({
-    "community.f5.com/source"      = "github.com/memes/terraform-volterra-gcp-vpc-site"
-    "community.f5.com/provisioner" = "terraform"
-    "community.f5.com/use-case"    = "automated-testing"
-    "community.f5.com/product"     = "terraform-google-volterra"
-    "community.f5.com/driver"      = "kitchen-terraform"
-  }, var.annotations)
-  gcp_labels = merge({
-    source      = "terraform-volterra-gcp-vpc-site"
-    provisioner = "terraform"
-    use-case    = "automated-testing"
-    product     = "terraform-google-volterra"
-    driver      = "kitchen-terraform"
-  }, var.labels)
+  prefix     = random_pet.prefix.id
   test_cidrs = coalescelist(var.test_cidrs, [format("%s/32", trimspace(data.http.my_address.response_body))])
   cidrs = {
     outside = {
@@ -134,8 +113,8 @@ resource "volterra_dc_cluster_group" "dc_outside" {
   name        = format("%s-outside", local.prefix)
   namespace   = "system" # var.namespace
   description = format("Outside DC cluster group (%s)", local.prefix)
-  annotations = local.annotations
-  labels      = local.labels
+  annotations = var.annotations
+  labels      = var.labels
 }
 
 resource "volterra_virtual_network" "outside_global" {
@@ -143,8 +122,8 @@ resource "volterra_virtual_network" "outside_global" {
   namespace      = "system"
   global_network = true
   description    = format("Outside test global network (%s)", local.prefix)
-  annotations    = local.annotations
-  labels         = local.labels
+  annotations    = var.annotations
+  labels         = var.labels
 }
 
 module "inside" {
@@ -172,8 +151,8 @@ resource "volterra_dc_cluster_group" "dc_inside" {
   name        = format("%s-inside", local.prefix)
   namespace   = "system" # var.namespace
   description = format("Inside DC cluster group (%s)", local.prefix)
-  annotations = local.annotations
-  labels      = local.labels
+  annotations = var.annotations
+  labels      = var.labels
 }
 
 resource "volterra_virtual_network" "inside_global" {
@@ -181,8 +160,8 @@ resource "volterra_virtual_network" "inside_global" {
   namespace      = "system"
   global_network = true
   description    = format("Inside test global network (%s)", local.prefix)
-  annotations    = local.annotations
-  labels         = local.labels
+  annotations    = var.annotations
+  labels         = var.labels
 }
 
 resource "google_compute_firewall" "test_ingress" {
@@ -243,8 +222,8 @@ resource "volterra_cloud_credentials" "xc" {
   name        = format("%s-gcp", local.prefix)
   namespace   = "system"
   description = format("GCP credentials (%s)", local.prefix)
-  annotations = local.annotations
-  labels      = local.labels
+  annotations = var.annotations
+  labels      = var.labels
   gcp_cred_file {
     credential_file {
       clear_secret_info {
@@ -281,16 +260,16 @@ resource "volterra_forward_proxy_policy" "allow_test" {
   any_proxy   = true
   allow_all   = true
   description = format("Test allow-all forward proxy policy (%s)", local.prefix)
-  annotations = local.annotations
-  labels      = local.labels
+  annotations = var.annotations
+  labels      = var.labels
 }
 
 resource "volterra_enhanced_firewall_policy" "allow_test" {
   name        = format("%s-allow-test", local.prefix)
   namespace   = "system"
   description = format("Test enhanced firewall policy (%s)", local.prefix)
-  annotations = local.annotations
-  labels      = local.labels
+  annotations = var.annotations
+  labels      = var.labels
   allowed_sources {
     prefix = local.test_cidrs
   }

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -60,15 +60,15 @@ output "ssh_pubkey" {
 }
 
 output "labels" {
-  value = local.labels
+  value = var.labels
 }
 
 output "annotations" {
-  value = local.annotations
+  value = var.annotations
 }
 
 output "gcp_labels" {
-  value = local.gcp_labels
+  value = var.gcp_labels
 }
 
 


### PR DESCRIPTION
The labels and annotations are used by consumers to apply identifiable tokens to F5 Distributed Cloud and GCP resources. This module should not be adding arbitrary entries.

Closes #36